### PR TITLE
Resizing bug when scrolling

### DIFF
--- a/src/masonry.ts
+++ b/src/masonry.ts
@@ -203,7 +203,9 @@ export class Masonry {
     }
 
     // Setting the container height to the tallest column's height
-    this.masonryContainer.style.height = `calc(${containerHeight - this.masonryContainer.getBoundingClientRect().top}px + ${this.gutter}${this.gutterUnit})`;
+    if (this.masonryContainer.getBoundingClientRect().top > 0) {
+      this.masonryContainer.style.height = `calc(${containerHeight - this.masonryContainer.getBoundingClientRect().top}px + ${this.gutter}${this.gutterUnit})`;
+    }
 
     // On init callback
     if (this.onInit) this.onInit();


### PR DESCRIPTION
Avoid resizing container when scrolling far past the Masonry on a page with many elements below the Masonry. `this.masonryContainer.getBoundingClientRect().top` becomes a very low negative number when scrolling past the Masonry. This, negative, number seems to be irrelevant to the calculation of the height of the Masonry. So perhaps it's enough to just check if the value is negative, and skip the setting of the height at this point.